### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ The 1st field consists of *sparse features*. All the elements in this field are 
 | 3rd Dora Indicator                                       | `92` ~ `128`                                         | optional, `92 + tile`           |
 | 4th Dora Indicator                                       | `129` ~ `165`                                        | optional, `129 + tile`          |
 | 5th Dora Indicator                                       | `166` ~ `202`                                        | optional, `166 + tile`          |
-| # of Left Tiles to Draw                                  | `203` ~ `272`                                        | `(# of left tiles) - 203`       |
+| # of Left Tiles to Draw                                  | `203` ~ `272`                                        | `203 + (# of left tiles)`       |
 | Grade of the player indicated by **Seat**                | `273` ~ `288`                                        | `273 + grade`                   |
 | Rank of the player indicated by **Seat**                 | `289` ~ `292`                                        | `289 + rank`                    |
 | Grade of the player right next to **Seat** (Seat の下家) | `293` ~ `308`                                        | `293 + grade`                   |


### PR DESCRIPTION
Probably a typo. `(# of left tiles) - 203` is always negative. The way to get the number of remaining tiles from the feature value is `(feature value) - 203`.

This PR modifies to align with the following code.

https://github.com/Cryolite/kanachan/blob/c832bb025063b22f96bf6da46ca3023207fab09e/src/simulation/round_state.cpp#L353